### PR TITLE
Update reusable workflows for terraform

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -11,7 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  apply-changes:
-    name: "Apply Changes"
-    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-apply-aws.yml@main
+  terraform:
+    name: "TF"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-apply.yml@main
+    with:
+      cloud_provider: aws
     secrets: inherit

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -10,7 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  plan-changes:
-    name: "Plan Changes"
-    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-plan-aws.yml@main
+  terraform:
+    name: "TF"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-plan.yml@main
+    with:
+      cloud_provider: aws
     secrets: inherit


### PR DESCRIPTION
This pull request updates the workflow files to use a more generic reusable GitHub Actions workflow for Terraform operations, replacing cloud-specific workflows. It also introduces a parameter to specify the cloud provider.

Updates to Terraform workflows:

* [`.github/workflows/terraform-apply.yml`](diffhunk://#diff-0470b92c7ad1159fdc694ea0893bd0e8bfad6d78173537f0e062e5e01aaf7f5eL14-R18): Replaced the `apply-changes` job with a more generic `terraform` job, updated the reusable workflow reference to `terraform-apply.yml`, and added the `cloud_provider` parameter set to `aws`.
* [`.github/workflows/terraform-plan.yml`](diffhunk://#diff-1ca63e6aac27d170492851d93ed42746d3493ce0db3c6ee7422efa4b7e3f0b6dL13-R17): Replaced the `plan-changes` job with a more generic `terraform` job, updated the reusable workflow reference to `terraform-plan.yml`, and added the `cloud_provider` parameter set to `aws`.